### PR TITLE
Implement a mechanism for setting script variables

### DIFF
--- a/examples/sample.config.lua
+++ b/examples/sample.config.lua
@@ -1,0 +1,8 @@
+-- config.lua
+-- This file contains the values of certain operating variables for
+-- properly enabled Lua scripts (e.g. neb_simple.lua)
+--
+
+number_of_internal_images_in_path = 5
+neb_spring_constant = 4.0
+


### PR DESCRIPTION
Some Lua scripts (e.g. the NEB example driver) have hard-wired
operational variables, such as the number of images, or the NEB spring constant.

A mechanism has been implemented to set those variables externally, through the
use of a 'configuration file' (typically named 'config.lua') and a new
variable environment.

A sample 'config.lua' file is provided for parametrizing 'neb_simple.lua'. Note that
*both* scripts must be present in the same directory.